### PR TITLE
Fix/only show links when there are any

### DIFF
--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -8,12 +8,13 @@ interface EventCardProps {
 }
 
 export const EventCard = ({event}: EventCardProps) => {
-
   const startDate = event.attributes?.startDate ? new Date(event.attributes?.startDate) : null
   const endDate = event.attributes?.endDate ? new Date(event.attributes?.endDate) : null
   const categories = event.attributes?.categories?.data ?? []
   const hasCategories = categories?.length > 0;
+
   const links = event.attributes?.urls ?? [];
+  const filteredLinks = links.filter((link: any) => link.link !== '' && link.description !== '')
 
   return (
     <>
@@ -36,12 +37,18 @@ export const EventCard = ({event}: EventCardProps) => {
               </div>
           }
 
-          {links.length > 0 &&
-              <div className={"grid grid-cols-3 gap-2"}>
-                <div className={"col-span-1 flex justify-end"}>Links</div>
-                <div
-                    className={"col-span-2"}>{links.filter((link: any) => link.link !== '' && link.description !== '').map((link: any, index: number) => <a className={"text-blue-700 underline"} href={link.link}>{index !== 0 && ", "}{link.description}</a>
-                )}</div>
+          {filteredLinks.length > 0 &&
+		        <div className={"grid grid-cols-3 gap-2"}>
+			        <div className={"col-span-1 flex justify-end"}>Links</div>
+			        <div
+				        className={"col-span-2"}>{
+                filteredLinks.map((link: any, index: number) =>
+                  <a className={"text-blue-700 underline"} href={link.link}>
+                    {index !== 0 && ", "}{link.description}
+                  </a>
+                )
+              }
+			        </div>
             </div>
           }
 

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -31,10 +31,10 @@ export const EventCard = ({event}: EventCardProps) => {
           <EventDate startDate={startDate} endDate={endDate}/>
 
           {hasCategories &&
-              <div className={"grid grid-cols-3 gap-2"}>
-                <div className={"col-span-1 flex justify-end"}>Kategorie</div>
-                <div className={"col-span-2"}>{categories?.map(c => c.attributes?.Name).join(", ")}</div>
-              </div>
+	          <div className={"grid grid-cols-3 gap-2"}>
+		          <div className={"col-span-1 flex justify-end"}>Kategorie</div>
+		          <div className={"col-span-2"}>{categories?.map(c => c.attributes?.Name).join(", ")}</div>
+	          </div>
           }
 
           {filteredLinks.length > 0 &&


### PR DESCRIPTION
This pull request includes changes to the `EventCard` component in `src/components/events/EventCard.tsx` to improve the handling and display of event links. The most important changes include filtering the event links and updating the rendering logic accordingly.

Improvements to event link handling:

* [`src/components/events/EventCard.tsx`](diffhunk://#diff-3aa509152cbd2988ad6c2efaa00b64a5b084679f5e0f9e5d6cf175b75e3dd1c2L11-R17): Added a `filteredLinks` variable to store only the links that have both a non-empty `link` and `description`.
* [`src/components/events/EventCard.tsx`](diffhunk://#diff-3aa509152cbd2988ad6c2efaa00b64a5b084679f5e0f9e5d6cf175b75e3dd1c2L39-R51): Updated the rendering logic to use `filteredLinks` instead of `links` to ensure only valid links are displayed.