### PR TITLE
Add recursive to build actions

### DIFF
--- a/.github/workflows/docker-image-tagged.yml
+++ b/.github/workflows/docker-image-tagged.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/docker-image_dev.yml
+++ b/.github/workflows/docker-image_dev.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to ensure submodules are checked out recursively. The most important changes are as follows:

Workflow updates:

* [`.github/workflows/docker-image-tagged.yml`](diffhunk://#diff-f9e2675e724986dc9da9455f53aa7338f7ce69bda42bdcd51c7a2aba38a4a6e4R22-R23): Added the `submodules: recursive` option to the `actions/checkout@v3` step.
* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cR23-R24): Added the `submodules: recursive` option to the `actions/checkout@v3` step.
* [`.github/workflows/docker-image_dev.yml`](diffhunk://#diff-b65206136142f2b636eb21b47a95abd7b138ae6cb2593648ff3fe7de95b79671R23-R24): Added the `submodules: recursive` option to the `actions/checkout@v3` step.